### PR TITLE
Fix uninitialized variable and raise exceptions with context

### DIFF
--- a/openhands/controller/agent_controller.py
+++ b/openhands/controller/agent_controller.py
@@ -683,7 +683,6 @@ class AgentController:
 
         # unset delegate so parent can resume normal handling
         self.delegate = None
-        self.delegateAction = None
 
     async def _step(self) -> None:
         """Executes a single step of the parent or delegate agent. Detects stuck agents and limits on the number of iterations and the task budget."""
@@ -763,9 +762,9 @@ class AgentController:
                         self._handle_long_context_error()
                         return
                     else:
-                        raise LLMContextWindowExceedError()
+                        raise LLMContextWindowExceedError() from e
                 else:
-                    raise e
+                    raise
 
         if action.runnable:
             if self.state.confirmation_mode and (

--- a/openhands/controller/state/state.py
+++ b/openhands/controller/state/state.py
@@ -137,7 +137,7 @@ class State:
             )
             pickled = base64.b64decode(encoded)
             state = pickle.loads(pickled)
-        except FileNotFoundError:
+        except FileNotFoundError as e:
             # if user_id is provided, we are in a saas/remote use case
             # and we need to check if the state is in the old directory.
             if user_id:
@@ -148,10 +148,10 @@ class State:
             else:
                 raise FileNotFoundError(
                     f'Could not restore state from session file for sid: {sid}'
-                )
+                ) from e
         except Exception as e:
             logger.debug(f'Could not restore state from session: {e}')
-            raise e
+            raise
 
         # update state
         if state.agent_state in RESUMABLE_STATES:

--- a/openhands/controller/state/task.py
+++ b/openhands/controller/state/task.py
@@ -182,15 +182,15 @@ class RootTask(Task):
         if id == '':
             return self
         if len(self.subtasks) == 0:
-            raise LLMMalformedActionError('Task does not exist:' + id)
+            raise LLMMalformedActionError('Task does not exist:' + id) from None
         try:
             parts = [int(p) for p in id.split('.')]
         except ValueError:
-            raise LLMMalformedActionError('Invalid task id:' + id)
+            raise LLMMalformedActionError('Invalid task id:' + id) from None
         task: Task = self
         for part in parts:
             if part >= len(task.subtasks):
-                raise LLMMalformedActionError('Task does not exist:' + id)
+                raise LLMMalformedActionError('Task does not exist:' + id) from None
             task = task.subtasks[part]
         return task
 

--- a/openhands/core/config/condenser_config.py
+++ b/openhands/core/config/condenser_config.py
@@ -249,4 +249,4 @@ def create_condenser_config(condenser_type: str, data: dict) -> CondenserConfig:
         # which can cause compatibility issues with different pydantic versions
         raise ValueError(
             f"Validation failed for condenser type '{condenser_type}': {e}"
-        )
+        ) from e

--- a/openhands/core/config/sandbox_config.py
+++ b/openhands/core/config/sandbox_config.py
@@ -95,6 +95,6 @@ class SandboxConfig(BaseModel):
         try:
             sandbox_mapping['sandbox'] = cls.model_validate(data)
         except ValidationError as e:
-            raise ValueError(f'Invalid sandbox configuration: {e}')
+            raise ValueError(f'Invalid sandbox configuration: {e}') from e
 
         return sandbox_mapping

--- a/openhands/core/config/security_config.py
+++ b/openhands/core/config/security_config.py
@@ -32,6 +32,6 @@ class SecurityConfig(BaseModel):
         try:
             security_mapping['security'] = cls.model_validate(data)
         except ValidationError as e:
-            raise ValueError(f'Invalid security configuration: {e}')
+            raise ValueError(f'Invalid security configuration: {e}') from e
 
         return security_mapping

--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -178,7 +178,7 @@ def load_from_toml(cfg: AppConfig, toml_file: str = 'config.toml') -> None:
             )
         except ValueError:
             # Re-raise ValueError from SecurityConfig.from_toml_section
-            raise ValueError('Error in [security] section in config.toml')
+            raise ValueError('Error in [security] section in config.toml') from None
 
     # Process sandbox section if present
     if 'sandbox' in toml_config:
@@ -193,7 +193,7 @@ def load_from_toml(cfg: AppConfig, toml_file: str = 'config.toml') -> None:
             )
         except ValueError:
             # Re-raise ValueError from SandboxConfig.from_toml_section
-            raise ValueError('Error in [sandbox] section in config.toml')
+            raise ValueError('Error in [sandbox] section in config.toml') from None
 
     # Process condenser section if present
     if 'condenser' in toml_config:

--- a/openhands/storage/s3.py
+++ b/openhands/storage/s3.py
@@ -126,15 +126,15 @@ class S3FileStore(FileStore):
             elif e.response['Error']['Code'] == 'NoSuchKey':
                 raise FileNotFoundError(
                     f"Error: The object key '{path}' does not exist in bucket '{self.bucket}'."
-                )
+                ) from e
             else:
                 raise FileNotFoundError(
                     f"Error: Failed to delete key '{path}' from bucket '{self.bucket}': {e}"
-                )
+                ) from e
         except Exception as e:
             raise FileNotFoundError(
                 f"Error: Failed to delete key '{path}' from bucket '{self.bucket}: {e}"
-            )
+            ) from e
 
     def _ensure_url_scheme(self, secure: bool, url: str | None) -> str | None:
         if not url:


### PR DESCRIPTION
## Summary
- remove unused `delegateAction` field
- keep original exception context in `AgentController`, configuration and storage modules
- adjust error handling for task restoration and ID parsing
- follow Ruff's guidance for raising exceptions

## Testing
- `ruff check openhands --select B | head -n 20`
- `pytest tests/unit/test_chunk_localizer.py::test_chunk_creation -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6846aada84b483239930bf1d9a80c1a3